### PR TITLE
fix make command method test failure

### DIFF
--- a/src/PopplerPhp/PopplerUtil.php
+++ b/src/PopplerPhp/PopplerUtil.php
@@ -23,7 +23,7 @@ abstract class PopplerUtil
     protected $bin_file;
     protected $output_file_extension;
     protected $require_output_dir = true;
-    protected $require_sub_dir    = true;
+    protected $require_sub_dir    = false;
     protected $output_file_suffix = '';
     private   $binary_dir;
     private   $flags              = [];
@@ -426,7 +426,7 @@ abstract class PopplerUtil
      */
     public function isSubDirRequired()
     {
-        return $this->output_sub_dir;
+        return $this->require_sub_dir;
     }
 
     /**
@@ -435,7 +435,7 @@ abstract class PopplerUtil
      */
     public function setSubDirRequired($bool)
     {
-        $this->output_sub_dir = $bool;
+        $this->require_sub_dir = $bool;
 
         return $this;
     }

--- a/src/PopplerPhp/PopplerUtil.php
+++ b/src/PopplerPhp/PopplerUtil.php
@@ -101,7 +101,7 @@ abstract class PopplerUtil
      */
     public function getOutputSubDir()
     {
-        if (!is_string($this->output_sub_dir)) {
+        if ($this->isSubDirRequired() && empty($this->output_sub_dir)) {
             $this->output_sub_dir = uniqid('test-'.date('m-d-Y_H-i'));
         }
 

--- a/src/PopplerPhp/PopplerUtil.php
+++ b/src/PopplerPhp/PopplerUtil.php
@@ -113,7 +113,13 @@ abstract class PopplerUtil
      */
     public function getOutputPath()
     {
-        return Config::getOutputDirectory().C::DS.($this->isSubDirRequired() ? $this->getOutputSubDir() : '');
+        $output_sub_dir = $this->getOutputSubDir();
+
+        if ($this->isSubDirRequired() && !empty($output_sub_dir)) {
+            return Config::getOutputDirectory().C::DS.$output_sub_dir;
+        }
+
+        return Config::getOutputDirectory();
     }
 
     /**

--- a/tests/PopplerUtilTest.php
+++ b/tests/PopplerUtilTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Poppler-PHP
  *
@@ -6,7 +7,6 @@
  * Date:    10/13/2016
  * Time:    2:31 PM
  **/
-
 use NcJoes\PopplerPhp\Config;
 use NcJoes\PopplerPhp\Constants as C;
 use NcJoes\PopplerPhp\PdfInfo;
@@ -14,6 +14,7 @@ use NcJoes\PopplerPhp\PdfToCairo;
 
 class PopplerUtilTest extends PHPUnit_Framework_TestCase
 {
+
     public function setUp()
     {
         parent::setUp();
@@ -64,14 +65,49 @@ class PopplerUtilTest extends PHPUnit_Framework_TestCase
 
     public function testMakeCommandMethod()
     {
+        $q = PHP_OS === 'WINNT' ? "\"" : "'";
         $DS = DIRECTORY_SEPARATOR;
         $file = __DIR__.$DS."sources{$DS}test1.pdf";
-        $pdf = new PdfToCairo($file);
+        $output_file_prefix = 'test-file';
 
-        $pdf->setOutputFilenamePrefix('test-file');
-        $this->assertTrue(str_contains($pdf->previewShellCommand(), $pdf->getOutputFilenamePrefix()));
-        //$this->assertTrue(str_contains($pdf->previewShellCommand(), $pdf->binDir()));
-        $this->assertTrue(str_contains($pdf->previewShellCommand(), $pdf->getOutputSubDir()));
+        $pdf = new PdfToCairo($file);
+        $pdf->setOutputFilenamePrefix($output_file_prefix);
+
+        $bin_dir = Config::getBinDirectory();
+        $bin_file = C::PDF_TO_CAIRO;
+        $output_dir = Config::getOutputDirectory();
+
+        $expected_bin = "{$q}{$bin_dir}{$DS}{$bin_file}{$q}";
+        $expected_src = "{$q}{$file}{$q}";
+        $expected_dest = "{$q}{$output_dir}{$DS}{$output_file_prefix}{$q}";
+        $this->assertRegExp(
+            "%^{$expected_bin} {$expected_src} {$expected_dest}$%",
+            $pdf->previewShellCommand()
+        );
     }
 
+    public function testMakeCommandMethodWithSubDirEnabled()
+    {
+        $q = PHP_OS === 'WINNT' ? "\"" : "'";
+        $DS = DIRECTORY_SEPARATOR;
+        $file = __DIR__.$DS."sources{$DS}test1.pdf";
+        $output_file_prefix = 'test-file';
+
+        $pdf = new PdfToCairo($file);
+        $pdf->setSubDirRequired(true);
+        $pdf->setOutputFilenamePrefix($output_file_prefix);
+
+        $bin_dir = Config::getBinDirectory();
+        $bin_file = C::PDF_TO_CAIRO;
+        $output_dir = Config::getOutputDirectory();
+        $output_sub_dir = $pdf->getOutputSubDir();
+
+        $expected_bin = "{$q}{$bin_dir}{$DS}{$bin_file}{$q}";
+        $expected_src = "{$q}{$file}{$q}";
+        $expected_dest = "{$q}{$output_dir}{$DS}{$output_sub_dir}{$DS}{$output_file_prefix}{$q}";
+        $this->assertRegExp(
+            "%^{$expected_bin} {$expected_src} {$expected_dest}$%",
+            $pdf->previewShellCommand()
+        );
+    }
 }


### PR DESCRIPTION
## Description

Fix testMakeCommandMethod failure.

## Root cause

`PopplerUtil::getOutputSubDir()` sets and returns new value of `output_sub_dir` if called with empty `output_sub_dir`.

## Changes

* Prevent `PopplerUtil::getOutputSubDir()` from setting new value to `output_sub_dir` if `isSubDirRequired() === false` 
* Use `require_sub_dir` in `PopplerUtil::isSubDirRequired()`
